### PR TITLE
Fixed chrome extension errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .DS_Store
 chrome.pem
+.tern-port

--- a/popup.html
+++ b/popup.html
@@ -23,6 +23,6 @@
       </section>
       <button id="reconnect" class="button" type="button" name="button" disabled>Reconnect</button>
     </main>
+    <script type="text/javascript" src="src/popup.js"></script>
   </body>
-  <script type="text/javascript" src="src/popup.js"></script>
 </html>

--- a/src/background.js
+++ b/src/background.js
@@ -1,123 +1,140 @@
-let socket = null
+let socket = null;
 
 // on params change
-chrome.storage.onChanged.addListener((changes) => {
-  const { params, reconnect } = changes
-
-  if (params) {
-    const { newValue, oldValue } = params
-    if (oldValue.active.id !== newValue.active.id) switchState(newValue.active, newValue.port)
-  }
-  // if (reconnect) {
-  //   const { newValue, oldValue } = reconnect
-  // }
-})
+chrome.storage.onChanged.addListener(changes => {
+    const { params, reconnect } = changes;
+    if (params) {
+        trySwitchStateForParams(params);
+    }
+    // if (reconnect) {
+    //   const { newValue, oldValue } = reconnect
+    // }
+});
 
 // on page load/reload
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    console.log(changeInfo);
+    const { status } = changeInfo;
 
-  console.log(changeInfo)
-  const { status } = changeInfo
+    if (status && status === 'complete') {
+        const domain = getDomain(tab.url);
 
-  if (status && status === 'complete') {
-    const domain = getDomain(tab.url)
-
-    chrome.storage.local.get([domain, 'params'], res => {
-      const { params } = res
-      if (params.active && params.active.id === tabId) {
-        chrome.browserAction.setIcon({ tabId, path: getIcons('on') })
-        const store = res[domain]
-        executeScript(store, tabId)
-      }
-    })
-  }
-})
+        chrome.storage.local.get([domain, 'params'], res => {
+            const { params } = res;
+            if (params.active && params.active.id === tabId) {
+                chrome.browserAction.setIcon({ tabId, path: getIcons('on') });
+                const store = res[domain];
+                executeScript(store, tabId);
+            }
+        });
+    }
+});
 
 const getDomain = url => {
-  const begin = url.startsWith('https') ? 8 : 7
-  const withoutProtocol = url.slice(begin)
-  const beginPath = withoutProtocol.indexOf('/')
-  if (!~beginPath) return withoutProtocol
-  return withoutProtocol.slice(0, withoutProtocol.indexOf('/'))
-}
+    const begin = url.startsWith('https') ? 8 : 7;
+    const withoutProtocol = url.slice(begin);
+    const beginPath = withoutProtocol.indexOf('/');
+    if (!~beginPath) return withoutProtocol;
+    return withoutProtocol.slice(0, withoutProtocol.indexOf('/'));
+};
 
 const switchState = (tab, port) => {
-  socket && socket.close()
-  socket = null
+    socket && socket.close();
+    socket = null;
 
-  if (tab.id) {
-    const domain = getDomain(tab.url)
-    if (!socket) socket = connect(domain, tab.id, port)
+    if (tab.id) {
+        const domain = getDomain(tab.url);
+        if (!socket)
+            socket = connect(
+                domain,
+                tab.id,
+                port
+            );
 
-    chrome.storage.local.get([domain], res => {
-      const store = res[domain]
-      executeScript(store, tab.id)
-    })
-  }
-}
+        chrome.storage.local.get([domain], res => {
+            const store = res[domain];
+            executeScript(store, tab.id);
+        });
+    }
+};
+
+const trySwitchStateForParams = ({ newValue, oldValue = { active: {} } }) => {
+    if (newValue && oldValue.active.id !== newValue.active.id) {
+        switchState(newValue.active, newValue.port);
+    }
+};
 
 const connect = (domain, tabId, port = 9999) => {
-  const socket = new WebSocket(`ws://localhost:${port}`)
+    const socket = new WebSocket(`ws://localhost:${port}`);
 
-  socket.onclose = ev => {
-    chrome.browserAction.setIcon({ tabId, path: getIcons('off') })
+    socket.onclose = ev => {
+        chrome.browserAction.setIcon({ tabId, path: getIcons('off') });
 
-    chrome.storage.local.get(['params'], ({ params }) => {
-      const newParams = { ...params, active: { id: false } }
-      chrome.storage.local.set({ params: newParams }, () => syncView(newParams))
-      chrome.tabs.executeScript(
-        tabId, 
-        { code: `console.log('[injector] Websocket was disconnected (code: ${ev.code})')` }
-      )
-    })
-  }
+        chrome.storage.local.get(['params'], ({ params }) => {
+            const newParams = { ...params, active: { id: false } };
+            chrome.storage.local.set({ params: newParams }, () =>
+                syncView(newParams)
+            );
+            chrome.tabs.executeScript(tabId, {
+                code: `console.log('[injector] Websocket was disconnected (code: ${
+                    ev.code
+                })')`
+            });
+        });
+    };
 
-  socket.onopen = () => {
-    chrome.browserAction.setIcon({ tabId, path: getIcons('on') })
-  }
+    socket.onopen = () => {
+        chrome.browserAction.setIcon({ tabId, path: getIcons('on') });
+    };
 
-  socket.onmessage = ev => {
-    const { data } = ev
-    const type = data.slice(0, 2) === 'st' ? 'style' : 'script'
-    const code = data.slice(2)
+    socket.onmessage = ev => {
+        const { data } = ev;
+        const type = data.slice(0, 2) === 'st' ? 'style' : 'script';
+        const code = data.slice(2);
 
-    chrome.storage.local.get([domain], res => {
-      if (res[domain] && res[domain][type] && res[domain][type] === code) return
-      const store = { ...res[domain], [type]: code }
-      chrome.storage.local.set({ [domain]: store }, () => reloadPage(tabId))
-    })
-  }
+        chrome.storage.local.get([domain], res => {
+            if (res[domain] && res[domain][type] && res[domain][type] === code)
+                return;
+            const store = { ...res[domain], [type]: code };
+            chrome.storage.local.set({ [domain]: store }, () =>
+                reloadPage(tabId)
+            );
+        });
+    };
 
-  socket.onerror = err => {
-    chrome.tabs.executeScript(tabId, { code: `console.log('Websocket error: ${err}')` })
-  }
+    socket.onerror = err => {
+        chrome.tabs.executeScript(tabId, {
+            code: `console.log('Websocket error: ${err}')`
+        });
+    };
 
-  return socket
-}
+    return socket;
+};
 
 const reloadPage = tabId => {
-  chrome.storage.local.get(['params'], ({ params }) => {
-    const { livereload } = params
-    if (livereload) chrome.tabs.executeScript(tabId, { code: 'location.reload()' })
-  })
-}
+    chrome.storage.local.get(['params'], ({ params }) => {
+        const { livereload } = params;
+        if (livereload)
+            chrome.tabs.executeScript(tabId, { code: 'location.reload()' });
+    });
+};
 
 const executeScript = (store, tabId) => {
-  chrome.storage.local.get(['params'], ({ params }) => {
-    const { log } = params
-    chrome.tabs.executeScript(
-      tabId,
-      { code: `var store = ${JSON.stringify({ ...store, log })}` },
-      () => {
-        chrome.tabs.executeScript(tabId, {file: 'src/content.js'})
-      }
-    )
-  })
-}
+    chrome.storage.local.get(['params'], ({ params }) => {
+        const { log } = params;
+        chrome.tabs.executeScript(
+            tabId,
+            { code: `var store = ${JSON.stringify({ ...store, log })}` },
+            () => {
+                chrome.tabs.executeScript(tabId, { file: 'src/content.js' });
+            }
+        );
+    });
+};
 
 const getIcons = state => {
-  return {
-    '64': `icons/${state}-64.png`,
-    '128': `icons/${state}-128.png`
-  }
-}
+    return {
+        '64': `icons/${state}-64.png`,
+        '128': `icons/${state}-128.png`
+    };
+};

--- a/src/background.js
+++ b/src/background.js
@@ -1,140 +1,135 @@
-let socket = null;
+let socket = null
 
 // on params change
 chrome.storage.onChanged.addListener(changes => {
-    const { params, reconnect } = changes;
-    if (params) {
-        trySwitchStateForParams(params);
-    }
-    // if (reconnect) {
-    //   const { newValue, oldValue } = reconnect
-    // }
-});
+  const { params, reconnect } = changes
+  if (params) {
+    trySwitchStateForParams(params)
+  }
+  // if (reconnect) {
+  //   const { newValue, oldValue } = reconnect
+  // }
+})
 
 // on page load/reload
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    console.log(changeInfo);
-    const { status } = changeInfo;
+  console.log(changeInfo)
+  const { status } = changeInfo
 
-    if (status && status === 'complete') {
-        const domain = getDomain(tab.url);
+  if (status && status === 'complete') {
+    const domain = getDomain(tab.url)
 
-        chrome.storage.local.get([domain, 'params'], res => {
-            const { params } = res;
-            if (params.active && params.active.id === tabId) {
-                chrome.browserAction.setIcon({ tabId, path: getIcons('on') });
-                const store = res[domain];
-                executeScript(store, tabId);
-            }
-        });
-    }
-});
+    chrome.storage.local.get([domain, 'params'], res => {
+      const { params } = res
+      if (params.active && params.active.id === tabId) {
+        chrome.browserAction.setIcon({ tabId, path: getIcons('on') })
+        const store = res[domain]
+        executeScript(store, tabId)
+      }
+    })
+  }
+})
 
 const getDomain = url => {
-    const begin = url.startsWith('https') ? 8 : 7;
-    const withoutProtocol = url.slice(begin);
-    const beginPath = withoutProtocol.indexOf('/');
-    if (!~beginPath) return withoutProtocol;
-    return withoutProtocol.slice(0, withoutProtocol.indexOf('/'));
-};
+  const begin = url.startsWith('https') ? 8 : 7
+  const withoutProtocol = url.slice(begin)
+  const beginPath = withoutProtocol.indexOf('/')
+  if (!~beginPath) return withoutProtocol
+  return withoutProtocol.slice(0, withoutProtocol.indexOf('/'))
+}
 
 const switchState = (tab, port) => {
-    socket && socket.close();
-    socket = null;
+  socket && socket.close()
+  socket = null
 
-    if (tab.id) {
-        const domain = getDomain(tab.url);
-        if (!socket)
-            socket = connect(
-                domain,
-                tab.id,
-                port
-            );
+  if (tab.id) {
+    const domain = getDomain(tab.url)
+    if (!socket)
+      socket = connect(
+        domain,
+        tab.id,
+        port
+      )
 
-        chrome.storage.local.get([domain], res => {
-            const store = res[domain];
-            executeScript(store, tab.id);
-        });
-    }
-};
+    chrome.storage.local.get([domain], res => {
+      const store = res[domain]
+      executeScript(store, tab.id)
+    })
+  }
+}
 
 const trySwitchStateForParams = ({ newValue, oldValue = { active: {} } }) => {
-    if (newValue && oldValue.active.id !== newValue.active.id) {
-        switchState(newValue.active, newValue.port);
-    }
-};
+  if (newValue && oldValue.active.id !== newValue.active.id) {
+    switchState(newValue.active, newValue.port)
+  }
+}
 
 const connect = (domain, tabId, port = 9999) => {
-    const socket = new WebSocket(`ws://localhost:${port}`);
+  const socket = new WebSocket(`ws://localhost:${port}`)
 
-    socket.onclose = ev => {
-        chrome.browserAction.setIcon({ tabId, path: getIcons('off') });
+  socket.onclose = ev => {
+    chrome.browserAction.setIcon({ tabId, path: getIcons('off') })
 
-        chrome.storage.local.get(['params'], ({ params }) => {
-            const newParams = { ...params, active: { id: false } };
-            chrome.storage.local.set({ params: newParams }, () =>
-                syncView(newParams)
-            );
-            chrome.tabs.executeScript(tabId, {
-                code: `console.log('[injector] Websocket was disconnected (code: ${
-                    ev.code
-                })')`
-            });
-        });
-    };
+    chrome.storage.local.get(['params'], ({ params }) => {
+      const newParams = { ...params, active: { id: false } }
+      chrome.storage.local.set({ params: newParams }, () => syncView(newParams))
+      chrome.tabs.executeScript(tabId, {
+        code: `console.log('[injector] Websocket was disconnected (code: ${
+          ev.code
+        })')`
+      })
+    })
+  }
 
-    socket.onopen = () => {
-        chrome.browserAction.setIcon({ tabId, path: getIcons('on') });
-    };
+  socket.onopen = () => {
+    chrome.browserAction.setIcon({ tabId, path: getIcons('on') })
+  }
 
-    socket.onmessage = ev => {
-        const { data } = ev;
-        const type = data.slice(0, 2) === 'st' ? 'style' : 'script';
-        const code = data.slice(2);
+  socket.onmessage = ev => {
+    const { data } = ev
+    const type = data.slice(0, 2) === 'st' ? 'style' : 'script'
+    const code = data.slice(2)
 
-        chrome.storage.local.get([domain], res => {
-            if (res[domain] && res[domain][type] && res[domain][type] === code)
-                return;
-            const store = { ...res[domain], [type]: code };
-            chrome.storage.local.set({ [domain]: store }, () =>
-                reloadPage(tabId)
-            );
-        });
-    };
+    chrome.storage.local.get([domain], res => {
+      if (res[domain] && res[domain][type] && res[domain][type] === code) return
+      const store = { ...res[domain], [type]: code }
+      chrome.storage.local.set({ [domain]: store }, () => reloadPage(tabId))
+    })
+  }
 
-    socket.onerror = err => {
-        chrome.tabs.executeScript(tabId, {
-            code: `console.log('Websocket error: ${err}')`
-        });
-    };
+  socket.onerror = err => {
+    chrome.tabs.executeScript(tabId, {
+      code: `console.log('Websocket error: ${err}')`
+    })
+  }
 
-    return socket;
-};
+  return socket
+}
 
 const reloadPage = tabId => {
-    chrome.storage.local.get(['params'], ({ params }) => {
-        const { livereload } = params;
-        if (livereload)
-            chrome.tabs.executeScript(tabId, { code: 'location.reload()' });
-    });
-};
+  chrome.storage.local.get(['params'], ({ params }) => {
+    const { livereload } = params
+    if (livereload)
+      chrome.tabs.executeScript(tabId, { code: 'location.reload()' })
+  })
+}
 
 const executeScript = (store, tabId) => {
-    chrome.storage.local.get(['params'], ({ params }) => {
-        const { log } = params;
-        chrome.tabs.executeScript(
-            tabId,
-            { code: `var store = ${JSON.stringify({ ...store, log })}` },
-            () => {
-                chrome.tabs.executeScript(tabId, { file: 'src/content.js' });
-            }
-        );
-    });
-};
+  chrome.storage.local.get(['params'], ({ params }) => {
+    const { log } = params
+    chrome.tabs.executeScript(
+      tabId,
+      { code: `var store = ${JSON.stringify({ ...store, log })}` },
+      () => {
+        chrome.tabs.executeScript(tabId, { file: 'src/content.js' })
+      }
+    )
+  })
+}
 
 const getIcons = state => {
-    return {
-        '64': `icons/${state}-64.png`,
-        '128': `icons/${state}-128.png`
-    };
-};
+  return {
+    '64': `icons/${state}-64.png`,
+    '128': `icons/${state}-128.png`
+  }
+}

--- a/src/popup.js
+++ b/src/popup.js
@@ -6,9 +6,9 @@ const logI = get('log')
 const portI = get('port')
 const reconnectI = get('reconnect')
 
-chrome.storage.local.get(['params'], ({ params }) => {
+chrome.storage.local.get(['params'], ({ params = { active: {} } }) => {
   chrome.tabs.query({ active: true }, ([tab]) => {
-    if (params.active.id === tab.id) syncView(params)
+    if (tab && params.active.id === tab.id) syncView(params)
     params.port && portI.setAttribute('placeholder', params.port)
   })
 })


### PR DESCRIPTION
1. Fixed errors chrome logged in extensions panel. They were caused by tries to get properties from undefined variables. Added default values and this fixed these issues.
2. Moved script tag inside body in popup.html file. Not sure if it was required, but code analyser showed error here.
3. Moved switch state based on params to separate function in src/background.js. I did this to reduce embed level and improve readability.
4. Ran src/background.js through Prettier. This is the reason for such amount of differences.